### PR TITLE
Core remove flattening

### DIFF
--- a/sqsgenerator/core/__init__.py
+++ b/sqsgenerator/core/__init__.py
@@ -5,15 +5,15 @@ import frozendict
 import typing as T
 
 
-from .iteration import __version__, __features__
-from .iteration import set_log_level, pair_sqs_iteration, pair_analysis
-from .iteration import IterationMode, IterationSettings, BoostLogLevel
+from sqsgenerator.core.iteration import __version__, __features__
+from sqsgenerator.core.iteration import set_log_level, pair_sqs_iteration, pair_analysis
+from sqsgenerator.core.iteration import IterationMode, IterationSettings, BoostLogLevel
 
-from .structure import Structure, structure_to_dict, Atom, make_supercell
+from sqsgenerator.core.structure import Structure, structure_to_dict, Atom, make_supercell
 
-from .data import SQSResult
+from sqsgenerator.core.data import SQSResult
 
-from .utils import default_shell_distances, total_permutations, rank_structure, atoms_from_numbers, \
+from sqsgenerator.core.utils import default_shell_distances, total_permutations, rank_structure, atoms_from_numbers, \
     atoms_from_symbols, available_species, symbols_from_z
 
 __all__ = [

--- a/sqsgenerator/core/include/types.hpp
+++ b/sqsgenerator/core/include/types.hpp
@@ -4,9 +4,11 @@
 
 #ifndef SQSGENERATOR_TYPES_HPP
 #define SQSGENERATOR_TYPES_HPP
-#include <vector>
+
 #include <map>
 #include <array>
+#include <chrono>
+#include <vector>
 #include <cstdint>
 #include <functional>
 #include <boost/multi_array.hpp>
@@ -33,6 +35,8 @@ namespace sqsgenerator {
     typedef std::vector<species_t> configuration_t;
     typedef std::vector<double> parameter_storage_t;
     typedef std::map<shell_t, double> pair_shell_weights_t;
+    typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_point_t;
+    typedef std::map<int, std::map<int, std::tuple<rank_t, rank_t>>> rank_iteration_map_t;
     using get_next_configuration_t = std::function<bool(configuration_t&)>;
     using get_next_configuration_ptr_t = std::function<bool(species_t*, size_t)>;
     template<size_t NDims>

--- a/sqsgenerator/core/include/utils.hpp
+++ b/sqsgenerator/core/include/utils.hpp
@@ -106,6 +106,10 @@ namespace boost{
         return message.str();
     }
 
+    template<typename MultiArray>
+    std::vector<typename MultiArray::element> to_flat_vector(const MultiArray &array) {
+        return std::vector<typename MultiArray::element>(array.data(), array.data() + array.num_elements());
+    }
 
     template<typename MultiArray, typename T1 = typename MultiArray::element>
     std::string format_matrix(MultiArray array) {


### PR DESCRIPTION
:zap: remove reduction of flat-symmetric to reduce complexity (performance)
:sparkles: added option to filter results with minimal objective (run.py)
:recycle: move from relative to absolute imports (__init__.py)
:art: move variable declarations inside loops calculate_objective (sqs.cpp)
:art: use auto instead of concrete types (sqs.cpp)
:recycle: move function local type-definitions to types.hpp (types.hpp)
:coffin: remove "make_reduction_vector" (sqs.cpp)
:coffin: remove "reduce_weights_matrices" (sqs.cpp)
:coffin: remove "expand_matrix" (sqs.cpp)
:bulb: add comments, on how MPI data synchronization works (sqs.cpp)
:art: rearrange variable declaration close to usage "do_pair_iterations" (sqs.cpp)
:bulb: improve existing comments
:art: improve parameter delcaration readability in "do_pair_iterations" (sqs.cpp)