### PR TITLE
:sparkles: compatibility for MSVC compiler and Windows 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,21 +33,10 @@ configure_file(${PROJECT_SOURCE_DIR}/sqsgenerator/core/include/version.hpp.in ${
 find_package(Boost REQUIRED COMPONENTS system python numpy log_setup log)
 message([BOOST]:INCLUDE_DIRS: ${Boost_INCLUDE_DIRS})
 message([BOOST]:LIBRARIES: ${Boost_LIBRARIES})
+message([BOOST]:LIBRARY_DIRS: ${Boost_LIBRARY_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 set(CMAKE_CXX_LIBRARIES ${Boost_LIBRARIES})
 
-
-# https://stackoverflow.com/questions/28887680/linking-boost-library-with-boost-use-static-lib-off-on-windows
-if (WIN32)
-  # disable autolinking in boost
-  add_definitions( -DBOOST_ALL_NO_LIB )
-
-  # force all boost libraries to dynamic link (we already disabled
-  # autolinking, so I don't know why we need this, but we do!)
-  add_definitions( -DBOOST_ALL_DYN_LINK )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
-
-endif()
 
 if(NOT Boost_USE_STATIC_LIBS)
     # There is an issue find FindBoost.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ message([BOOST]:LIBRARIES: ${Boost_LIBRARIES})
 include_directories(${Boost_INCLUDE_DIRS})
 set(CMAKE_CXX_LIBRARIES ${Boost_LIBRARIES})
 
+if (WIN32)
+    add_definitions(-DBOOST_ALL_NO_LIB)
+    add_definitions(-DBOOST_ALL_DYN_LINK)
+endif()
+
 if(NOT Boost_USE_STATIC_LIBS)
     # There is an issue find FindBoost.cmake
     # https://gitlab.kitware.com/cmake/cmake/-/issues/20638: That's why log setup is added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,17 @@ message([BOOST]:LIBRARIES: ${Boost_LIBRARIES})
 include_directories(${Boost_INCLUDE_DIRS})
 set(CMAKE_CXX_LIBRARIES ${Boost_LIBRARIES})
 
+
+# https://stackoverflow.com/questions/28887680/linking-boost-library-with-boost-use-static-lib-off-on-windows
 if (WIN32)
-    add_definitions(-DBOOST_ALL_NO_LIB)
-    add_definitions(-DBOOST_ALL_DYN_LINK)
+  # disable autolinking in boost
+  add_definitions( -DBOOST_ALL_NO_LIB )
+
+  # force all boost libraries to dynamic link (we already disabled
+  # autolinking, so I don't know why we need this, but we do!)
+  add_definitions( -DBOOST_ALL_DYN_LINK )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+
 endif()
 
 if(NOT Boost_USE_STATIC_LIBS)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![conda](https://anaconda.org/conda-forge/sqsgenerator/badges/installer/conda.svg) 
+![plats](https://anaconda.org/conda-forge/sqsgenerator/badges/platforms.svg)
 ![downloads](
 https://anaconda.org/conda-forge/sqsgenerator/badges/downloads.svg)
 [![Documentation Status](https://readthedocs.org/projects/sqsgenerator/badge/?version=latest)](https://sqsgenerator.readthedocs.io/en/latest/?badge=latest)

--- a/docs/source/installation_guide.md
+++ b/docs/source/installation_guide.md
@@ -7,7 +7,7 @@
 (optional-dependencies)=
 
 [`ase`](https://wiki.fysik.dtu.dk/ase/) and [`pymatgen`](https://pymatgen.org/) are not explicitly listed as
-dependencies of `sqsgenerator`. However we **strongly encourage** you to install at least one of them.
+dependencies of `sqsgenerator`. However, we **strongly encourage** you to install at least one of them.
 `sqsgenerator` uses those packages as backends to export the its results into different file formats. Without
 `ase` or `pymatgen` results can be exported in YAML format only.
 
@@ -57,17 +57,19 @@ Python interpreter you build `sqsgenerator` against.
 
 ### Environment variable forwarding
 
-`sqsgenerator`'s `setup.py` forwards all environment variables with a `SQS_` prefix to **cmake**.
-This allows you to create the binaries with your own configuration.
+`sqsgenerator`'s `setup.py` forwards all environment variables with a `SQS_` prefix to *CMake*.
+This allows you to create the binaries with your own configuration. All variables of form `SQS_{VARNAME}={VALUE}` will
+be forwarded to *CMake* as `-D{VARNAME}={VALUE}` via the *setup.py* script.
+
 E. g. [FindBoost.cmake](https://cmake.org/cmake/help/latest/module/FindBoost.html#hints) takes a `BOOST_ROOT` hint to allow
-the use of a custom boost version. Therefore to build `sqsgenerator` with your own Boost version use 
+the use of a custom boost version. Therefore, to build `sqsgenerator` with your own Boost version use 
 
 
    ```{code-block} bash
    SQS_BOOST_ROOT=/path/to/own/boost pip install # add SQS_USE_MPI=ON for MPI enabled build
    ```
 
-The above code will under-the-hood call **cmake** with a `-DBOOST_ROOT=/path/to/own/boost` option.
+The above code will under-the-hood call *CMake* with a `-DBOOST_ROOT=/path/to/own/boost` option.
 
 In the same manner values can be passed to [FindMPI.cmake](https://cmake.org/cmake/help/latest/module/FindMPI.html).
 
@@ -89,7 +91,7 @@ With `conda` it is easy to install the needed toolchain, and thus get to a quick
 
     ```{code-block} bash
     conda activate sqs-build
-    conda install -c anaconda boost boost-cpp
+    conda install -c conda-forge boost boost-cpp
     # in case you do not have a system g++/cmake
     conda install -c anaconda cmake gxx_linux-64 
     ```
@@ -107,7 +109,7 @@ With `conda` it is easy to install the needed toolchain, and thus get to a quick
 4. **Build & install** the package<br>
     
     To ensure that we use Anaconda's `boost` libs (in case also system libraries are installed) we have to give 
-    **cmake** a hint, where to find them. The same is true if you want to use Anacondas C++ compiler (`CMAKE_CXX_COMPILER="x86_64-conda-linux-gnu-g++"`)
+    *CMake* a hint, where to find them. The same is true if you want to use Anacondas C++ compiler (`CMAKE_CXX_COMPILER="x86_64-conda-linux-gnu-g++"`)
 
     ```{code-block} bash
     cd sqsgenerator
@@ -119,15 +121,16 @@ With `conda` it is easy to install the needed toolchain, and thus get to a quick
    
     In case you want to build a MPI build version you have to add `SQS_USE_MPI=ON` to the installation instructions.
     In case you also want to link it against a specifiy MPI implementation (e. g. on a HPC cluster) you can instruct
-    *cmake* to so, by adding `SQS_MPI_HOME` which points the installation directory 
+    *CMake* to so, by adding `SQS_MPI_HOME` which points the installation directory 
 
     ```{code-block} bash
     cd sqsgenerator
     # SQS_MPI_HOME=/path/to/mpi/implementation/root
     SQS_USE_MPI=ON \
-    SQS_Boost_USE_STATIC_LIBS=ON \
     SQS_Boost_INCLUDE_DIR="${CONDA_PREFIX}/include" \
     SQS_Boost_LIBRARY_DIR_RELEASE="${CONDA_PREFIX}/lib" \
-    CMAKE_CXX_COMPILER="x86_64-conda-linux-gnu-g++" \
     pip install .
     ```
+
+    On UNIX* systems boost might be installed already by the system package manager. Hence, `SQS_Boost_INCLUDE_DIR`
+    and `SQS_Boost_LIBRARY_DIR_RELEASE` point *CMake* to the installation from the conda-environment.

--- a/setup.py
+++ b/setup.py
@@ -88,14 +88,15 @@ class CMakeBuildExt(build_ext):
                     # we append them to our release/debug flags
                     cmake_cxx_flags += f' {env_var_value}'
                 elif env_var_name.startswith('CMAKE'):
+                    print(f'sqsgenerator.setup: Forwarding env-var "{env_var_name}" -> "-D{env_var_name}"')
                     cmake_args.append(f'-D{env_var_name}={env_var_value}')
                 m = re.match(f'{env_var_prefix}(?P<varname>\w+)', env_var_name)
                 if m:
                     env_var_name_real = m.groupdict()['varname']
+                    print(f'sqsgenerator.setup: Forwarding env-var "{env_var_name}" -> "-D{env_var_name_real}"')
                     cmake_args.append(f'-D{env_var_name_real}={env_var_value}')
 
             cmake_args.append(f'-DCMAKE_CXX_FLAGS_{cfg.upper()}={cmake_cxx_flags}')
-            pprint.pprint(cmake_args)
             # We can handle some platform-specific settings at our discretion
             if platform.system() == 'Windows':
                 print('sqsgenerator.setup.py -> configuring CMake for Windows')
@@ -103,7 +104,7 @@ class CMakeBuildExt(build_ext):
                 cmake_args += [
                     # These options are likely to be needed under Windows
                     '-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE',
-                    # f'-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}'
+                    f'-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}'
                 ]
                 # Assuming that Visual Studio and MinGW are supported compilers
                 if self.compiler.compiler_type == 'msvc':
@@ -116,6 +117,7 @@ class CMakeBuildExt(build_ext):
                         '-G', 'MinGW Makefiles',
                     ]
 
+            pprint.pprint(cmake_args)
             subprocess.check_call(['cmake', ext.cmake_lists_dir] + cmake_args, cwd=self.build_temp)
             cmake_build_args = ['cmake', '--build', '.', '--config', cfg]
             if ext.target: cmake_build_args += ['--target', ext.target]

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ class CMakeBuildExt(build_ext):
                         if env_var_name not in cmake_var_whitelist:
                             print(f'sqsgenerator.setup: Blocking env-var "{env_var_name}" '
                                   f'since it is not whitelisted in {whitelist_env_var_name}')
-                        continue
+                            continue
                     print(f'sqsgenerator.setup: Forwarding env-var "{env_var_name}" -> "-D{env_var_name}"')
                     cmake_args.append(f'-D{env_var_name}={env_var_value}')
                 m = re.match(f'{env_var_prefix}(?P<varname>\w+)', env_var_name)

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
         'build_ext': CMakeBuildExt,
         'install': InstallCustom
     },
-    install_requires=['numpy', 'click', 'rich>=9.11.0', 'pyyaml', 'frozendict'],
+    install_requires=['six', 'numpy', 'click', 'rich>=9.11.0', 'pyyaml', 'frozendict'],
     entry_points={
         'console_scripts': ['sqsgen=sqsgenerator.cli:cli']
     },

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ class CMakeBuildExt(build_ext):
                     print(f'sqsgenerator.setup: Forwarding env-var "{env_var_name}" -> "-D{env_var_name_real}"')
                     cmake_args.append(f'-D{env_var_name_real}={env_var_value}')
 
-            cmake_args.append(f'-DCMAKE_CXX_FLAGS_{cfg.upper()}={cmake_cxx_flags}')
+
             # We can handle some platform-specific settings at our discretion
             if platform.system() == 'Windows':
                 print('sqsgenerator.setup.py -> configuring CMake for Windows')
@@ -133,7 +133,11 @@ class CMakeBuildExt(build_ext):
                         '-G', 'MinGW Makefiles',
                     ]
 
+            cmake_args.append(f'-DCMAKE_CXX_FLAGS_{cfg.upper()}={cmake_cxx_flags}')
+
+            # for debugging reasons we print the actual config which is passed to cmake
             pprint.pprint(cmake_args)
+
             subprocess.check_call(['cmake', ext.cmake_lists_dir] + cmake_args, cwd=self.build_temp)
             cmake_build_args = ['cmake', '--build', '.', '--config', cfg]
             if ext.target: cmake_build_args += ['--target', ext.target]

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -23,11 +23,6 @@ link_directories(${Boost_LIBRARY_DIRS})
 # https://stackoverflow.com/questions/28887680/linking-boost-library-with-boost-use-static-lib-off-on-windows
 if (WIN32)
 
-  # disable auto-linking in boost
-  add_definitions(-DBOOST_ALL_NO_LIB)
-  add_definitions(-DBOOST_ALL_DYN_LINK)
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-
   # add permissive flags
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
 

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(core SHARED
 
 if (WIN32)
   set_target_properties(core PROPERTIES SUFFIX .pyd)
+  target_link_libraries(core ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 
 if (UNIX AND NOT APPLE)
@@ -44,12 +45,13 @@ endif()
 
 if (LINUX)
     set_target_properties(core PROPERTIES SUFFIX .so)
+    target_link_libraries(core pthread ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 else()
     set_target_properties(core PROPERTIES SUFFIX .dylib)
+    target_link_libraries(core pthread ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 
 set_target_properties(core PROPERTIES PREFIX "")
-target_link_libraries(core pthread ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 if (USE_MPI)
     target_link_libraries(core ${MPI_CXX_LIBRARIES})
 endif()

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -37,19 +37,11 @@ add_library(core SHARED
 if (WIN32)
   set_target_properties(core PROPERTIES SUFFIX .pyd)
   target_link_libraries(core ${Python3_LIBRARIES} ${Boost_LIBRARIES})
-endif()
-
-if (UNIX AND NOT APPLE)
-    set(LINUX TRUE)
-endif()
-
-if (LINUX)
+else()
     set_target_properties(core PROPERTIES SUFFIX .so)
     target_link_libraries(core pthread ${Python3_LIBRARIES} ${Boost_LIBRARIES})
-else()
-    set_target_properties(core PROPERTIES SUFFIX .dylib)
-    target_link_libraries(core pthread ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 endif()
+
 
 set_target_properties(core PROPERTIES PREFIX "")
 if (USE_MPI)

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -33,7 +33,21 @@ add_library(core SHARED
         ${SQSGENERATOR_SOURCE_DIR}/structure_utils.cpp
          )
 
-set_target_properties(core PROPERTIES SUFFIX .so)
+
+if (WIN32)
+  set_target_properties(core PROPERTIES SUFFIX .pyd)
+endif()
+
+if (UNIX AND NOT APPLE)
+    set(LINUX TRUE)
+endif()
+
+if (LINUX)
+    set_target_properties(core PROPERTIES SUFFIX .so)
+else()
+    set_target_properties(core PROPERTIES SUFFIX .dylib)
+endif()
+
 set_target_properties(core PROPERTIES PREFIX "")
 target_link_libraries(core pthread ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 if (USE_MPI)

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -18,6 +18,34 @@ include_directories(${SQSGENERATOR_INCLUDE_DIR} include)
 include_directories(${Python3_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Python3_LIBRARY_DIRS})
+link_directories(${Boost_LIBRARY_DIRS})
+
+# https://stackoverflow.com/questions/28887680/linking-boost-library-with-boost-use-static-lib-off-on-windows
+if (WIN32)
+
+  # disable autolinking in boost
+  add_definitions(-DBOOST_ALL_NO_LIB )
+
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
+  # force all boost libraries to dynamic link (we already disabled
+  # autolinking, so I don't know why we need this, but we do!)
+  add_definitions(-DBOOST_ALL_DYN_LINK )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+
+  include(FetchContent)
+  # on Windows MSVC compiler is missing 128 unsigned integers, we therefore use https://github.com/calccrypto/uint128_t
+  FetchContent_Declare(
+     uint128t
+     GIT_REPOSITORY https://github.com/calccrypto/uint128_t.git
+     GIT_TAG ddc03839ea7efb78fa504ae8ecc2304e5ba80c3c
+  )
+
+  FetchContent_MakeAvailable(uint128t)
+
+  include_directories(${FETCHCONTENT_BASE_DIR}/uint128t-src)
+endif()
+
 
 add_library(core SHARED
         module_core.cpp
@@ -31,7 +59,7 @@ add_library(core SHARED
         ${SQSGENERATOR_SOURCE_DIR}/rank.cpp
         ${SQSGENERATOR_SOURCE_DIR}/utils.cpp
         ${SQSGENERATOR_SOURCE_DIR}/structure_utils.cpp
-         )
+)
 
 
 if (WIN32)

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -23,7 +23,12 @@ link_directories(${Boost_LIBRARY_DIRS})
 # https://stackoverflow.com/questions/28887680/linking-boost-library-with-boost-use-static-lib-off-on-windows
 if (WIN32)
 
-  # disable autolinking in boost
+  # disable auto-linking in boost
+  add_definitions(-DBOOST_ALL_NO_LIB)
+  add_definitions(-DBOOST_ALL_DYN_LINK)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
+  # add permissive flags
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
 
   include(FetchContent)

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -24,13 +24,6 @@ link_directories(${Boost_LIBRARY_DIRS})
 if (WIN32)
 
   # disable autolinking in boost
-  add_definitions(-DBOOST_ALL_NO_LIB )
-
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-
-  # force all boost libraries to dynamic link (we already disabled
-  # autolinking, so I don't know why we need this, but we do!)
-  add_definitions(-DBOOST_ALL_DYN_LINK )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
 
   include(FetchContent)

--- a/sqsgenerator/core/python/CMakeLists.txt
+++ b/sqsgenerator/core/python/CMakeLists.txt
@@ -37,10 +37,8 @@ if (WIN32)
   FetchContent_MakeAvailable(uint128t)
 
   include_directories(${FETCHCONTENT_BASE_DIR}/uint128t-src)
-endif()
 
-
-add_library(core SHARED
+  add_library(core SHARED
         module_core.cpp
         data.cpp
         iteration.cpp
@@ -52,7 +50,24 @@ add_library(core SHARED
         ${SQSGENERATOR_SOURCE_DIR}/rank.cpp
         ${SQSGENERATOR_SOURCE_DIR}/utils.cpp
         ${SQSGENERATOR_SOURCE_DIR}/structure_utils.cpp
-)
+        ${FETCHCONTENT_BASE_DIR}/uint128t-src/uint128_t.cpp
+  )
+
+else()
+    add_library(core SHARED
+        module_core.cpp
+        data.cpp
+        iteration.cpp
+        helpers.cpp
+        ${SQSGENERATOR_SOURCE_DIR}/sqs.cpp
+        ${SQSGENERATOR_SOURCE_DIR}/settings.cpp
+        ${SQSGENERATOR_SOURCE_DIR}/atomistics.cpp
+        ${SQSGENERATOR_SOURCE_DIR}/result.cpp
+        ${SQSGENERATOR_SOURCE_DIR}/rank.cpp
+        ${SQSGENERATOR_SOURCE_DIR}/utils.cpp
+        ${SQSGENERATOR_SOURCE_DIR}/structure_utils.cpp
+    )
+endif()
 
 
 if (WIN32)

--- a/sqsgenerator/core/python/helpers.hpp
+++ b/sqsgenerator/core/python/helpers.hpp
@@ -137,7 +137,7 @@ namespace sqsgenerator::python::helpers {
         std::map<K,V> result;
         py::list keys = d.keys();
         auto length {py::len(d)};
-        for (ssize_t i = 0; i < length ; i++) {
+        for (size_t i = 0; i < length ; i++) {
             K key = py::extract<K>(keys[i]);
             V val = py::extract<V>(d[key]);
             result.emplace(std::make_pair(key, val));

--- a/sqsgenerator/core/python/module_core.cpp
+++ b/sqsgenerator/core/python/module_core.cpp
@@ -1,10 +1,8 @@
 //
 // Created by dominik on 02.09.21.
 //
-#if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
-#define snprintf _snprintf
-#endif
 
+#include <stdio>
 #include "version.hpp"
 #include "types.hpp"
 #include "sqs.hpp"

--- a/sqsgenerator/core/python/module_core.cpp
+++ b/sqsgenerator/core/python/module_core.cpp
@@ -2,6 +2,13 @@
 #if defined(_WIN32) || defined(_WIN64)
 #include <stdio.h>
 #endif
+
+#if defined(_WIN32) || defined(_WIN64) && !defined(HAVE_SNPRINTF)
+#define HAVE_SNPRINTF
+#define snprintf _snprintf
+#define vsnprintf _vsnprintf
+#endif
+
 #include "version.hpp"
 #include "types.hpp"
 #include "sqs.hpp"

--- a/sqsgenerator/core/python/module_core.cpp
+++ b/sqsgenerator/core/python/module_core.cpp
@@ -1,8 +1,7 @@
-//
-// Created by dominik on 02.09.21.
-//
 
-#include <stdio>
+#if defined(_WIN32) || defined(_WIN64)
+#include <stdio.h>
+#endif
 #include "version.hpp"
 #include "types.hpp"
 #include "sqs.hpp"

--- a/sqsgenerator/core/python/module_core.cpp
+++ b/sqsgenerator/core/python/module_core.cpp
@@ -3,6 +3,7 @@
 //
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 #define snprintf _snprintf
+#endif
 
 #include "version.hpp"
 #include "types.hpp"

--- a/sqsgenerator/core/python/module_core.cpp
+++ b/sqsgenerator/core/python/module_core.cpp
@@ -1,10 +1,9 @@
 //
 // Created by dominik on 02.09.21.
 //
+#if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
+#define snprintf _snprintf
 
-//
-// Created by dominik on 14.07.21.
-//
 #include "version.hpp"
 #include "types.hpp"
 #include "sqs.hpp"

--- a/sqsgenerator/core/src/sqs.cpp
+++ b/sqsgenerator/core/src/sqs.cpp
@@ -145,19 +145,26 @@ namespace sqsgenerator {
 #endif
 
     std::tuple<std::vector<SQSResult>, timing_map_t> do_pair_iterations(const IterationSettings &settings) {
-        typedef boost::circular_buffer<SQSResult> result_buffer_t; // this typedef is an implementation detail and used just in this method
-        auto threads_per_rank {settings.threads_per_rank()};
+    typedef boost::circular_buffer<SQSResult> result_buffer_t; // this typedef is an implementation detail and used just in this method
+    auto threads_per_rank {settings.threads_per_rank()};
 
-        // setup the signal handler
+    // setup the signal handler
+#if defined(_WIN32) || defined(_WIN64)
+    typedef void (*signal_handler_ptr)(int);
+    signal_handler_ptr old_sigint_handler, old_sigabrt_handler;
+    old_sigint_handler = signal(SIGINT, handle_signal_sigint);
+    old_sigabrt_handler = signal(SIGABRT, handle_signal_sigint);
+#else
+    struct sigaction old_sigint_handler;
+    {
+        struct sigaction new_sigint_handler;
+        new_sigint_handler.sa_handler = handle_signal_sigint;
+        sigemptyset(&new_sigint_handler.sa_mask);
+        new_sigint_handler.sa_flags = 0x0;
+        sigaction(SIGINT, &new_sigint_handler, &old_sigint_handler);
+    }
+#endif
 
-        struct sigaction old_sigint_handler;
-        {
-            struct sigaction new_sigint_handler;
-            new_sigint_handler.sa_handler = handle_signal_sigint;
-            sigemptyset(&new_sigint_handler.sa_mask);
-            new_sigint_handler.sa_flags = 0x0;
-            sigaction(SIGINT, &new_sigint_handler, &old_sigint_handler);
-        }
 #if defined(USE_MPI)
         /*
          * Upon hitting Ctrl+C Python has registered it's own signal handler which raises the Keyboard interrupt
@@ -165,6 +172,10 @@ namespace sqsgenerator {
          * "mpiexec" a SIGTERM is propagated to all child processes, therefore we also put a handler for this signal
          * See: https://www.open-mpi.org/doc/v3.0/man1/mpirun.1.php#sect15
          */
+    #if defined(_WIN32) || defined(_WIN64)
+        signal_handler_ptr old_sigterm_handler;
+        old_sigterm_handler = signal(SIGTERM, handle_signal_sigterm);
+    #else
         struct sigaction old_sigterm_handler;
         {
             struct sigaction new_sigterm_handler;
@@ -173,6 +184,7 @@ namespace sqsgenerator {
             new_sigterm_handler.sa_flags = 0x0;
             sigaction(SIGTERM, &new_sigterm_handler, &old_sigterm_handler);
         }
+    #endif
 #endif
 
 #if defined(USE_MPI)
@@ -402,11 +414,20 @@ namespace sqsgenerator {
         } // pragma omp parallel
 
         // Restore the the old sigaction handler
-        sigaction(SIGINT, &old_sigint_handler, NULL);
+        #if defined(_WIN32) || defined(_WIN64)
+            signal(SIGINT, &old_sigint_handler);
+            signal(SIGABRT, &old_sigabrt_handler);
+        #else
+            sigaction(SIGINT, &old_sigint_handler, NULL);
+        #endif
 
 #if defined(USE_MPI)
         // For the MPI-version we also have to restore the SIGTERM handler
-        sigaction(SIGTERM, &old_sigterm_handler, NULL);
+        #if defined(_WIN32) || defined(_WIN64)
+            signal(SIGTERM, &old_sigterm_handler);
+        #else
+            sigaction(SIGTERM, &old_sigterm_handler, NULL);
+        #endif
 #endif
 
         if ((do_shutdown && shutdown_requested.load())) {

--- a/sqsgenerator/core/src/sqs.cpp
+++ b/sqsgenerator/core/src/sqs.cpp
@@ -14,7 +14,6 @@
 #endif
 #include <atomic>
 #include <chrono>
-#include <unistd.h>
 #include <signal.h>
 #include <unordered_set>
 #include <boost/circular_buffer.hpp>

--- a/sqsgenerator/core/src/sqs.cpp
+++ b/sqsgenerator/core/src/sqs.cpp
@@ -415,8 +415,8 @@ namespace sqsgenerator {
 
         // Restore the the old sigaction handler
         #if defined(_WIN32) || defined(_WIN64)
-            signal(SIGINT, &old_sigint_handler);
-            signal(SIGABRT, &old_sigabrt_handler);
+            signal(SIGINT, old_sigint_handler);
+            signal(SIGABRT, old_sigabrt_handler);
         #else
             sigaction(SIGINT, &old_sigint_handler, NULL);
         #endif
@@ -424,7 +424,7 @@ namespace sqsgenerator {
 #if defined(USE_MPI)
         // For the MPI-version we also have to restore the SIGTERM handler
         #if defined(_WIN32) || defined(_WIN64)
-            signal(SIGTERM, &old_sigterm_handler);
+            signal(SIGTERM, old_sigterm_handler);
         #else
             sigaction(SIGTERM, &old_sigterm_handler, NULL);
         #endif

--- a/sqsgenerator/core/src/utils.cpp
+++ b/sqsgenerator/core/src/utils.cpp
@@ -3,6 +3,12 @@
 //
 
 #include "utils.hpp"
+#if defined(_WIN32) || defined(_WIN64)
+#include "uint128_t.h"
+#define UINT128_T uint128_t
+#else
+#define UINT128_T __uint128_t
+#endif
 
 namespace sqsgenerator::utils {
 
@@ -46,10 +52,10 @@ namespace sqsgenerator::utils {
     // Code taken from: https://github.com/lemire/testingRNG/blob/master/source/wyhash.h
     static inline uint64_t wyhash64_stateless(uint64_t *seed) {
         *seed += UINT64_C(0x60bee2bee120fc15);
-        __uint128_t tmp;
-        tmp = (__uint128_t)*seed * UINT64_C(0xa3b195354a39b70d);
+        UINT128_T tmp;
+        tmp = (UINT128_T)*seed * UINT64_C(0xa3b195354a39b70d);
         uint64_t m1 = (tmp >> 64) ^ tmp;
-        tmp = (__uint128_t)m1 * UINT64_C(0x1b03738712fad5c9);
+        tmp = (UINT128_T)m1 * UINT64_C(0x1b03738712fad5c9);
         uint64_t m2 = (tmp >> 64) ^ tmp;
         return m2;
     }
@@ -61,6 +67,7 @@ namespace sqsgenerator::utils {
          uint64_t m = uint64_t(x) * uint64_t(range);
          return m >> 32;
     }
+
     // Simple Knuth-Fisher-Yates shuffle with random generator
     void shuffle_configuration_(configuration_t &configuration, uint64_t *seed) {
         for (uint32_t i=configuration.size(); i > 1; i--) {


### PR DESCRIPTION
:rotating_light: fix MSVC _vsnprintf compiler error on MSVC
:wrench: selective CMAKE variable forwarding in *setup.py*
:wrench: add [calccrypto/uint128_t](https://github.com/calccrypto/uint128_t) type for in builds in *CMakeLists.txt*
:bug: CMAKE_CXX_FLAGS are appended after win config section
:rotating_light: custom signal handling for win
:label: change `__uint128_t` type for MSVC to  [calccrypto/uint128_t](https://github.com/calccrypto/uint128_t)
:wrench: **.so** extension suffixes on Linux and OSX. **.pyd** in Windows
:rotating_light: fallback to OpenMP 2.0 on MSVC
