### PR TITLE
Add Python support for seeded random sqsgenerator runs

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -96,6 +96,33 @@ sublattices independently, in case more than one is specified. In *split* mode t
   :::
   ::::
 
+### `seed`
+(input-param-seed)=
+
+Optional random seed used when `iteration_mode` is `random`. If omitted, *sqsgenerator* seeds the
+shuffle generator from the system RNG. If specified, repeated runs with the same configuration,
+seed, and thread setup will be reproducible.
+
+- **Required:** No
+- **Default:** randomly generated
+- **Accepted:** unsigned 64-bit integer (`int`)
+
+  ::::{tab} JSON
+  :::{code-block} json
+  {
+    "seed": 42
+  }
+  :::
+  ::::
+
+  ::::{tab} Python
+  :::{code-block} python
+  {
+      "seed": 42
+  }
+  :::
+  ::::
+
 ### `bin_width`
 (input-param-bin-width)=
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -103,14 +103,29 @@ Optional random seed used when `iteration_mode` is `random`. If omitted, *sqsgen
 shuffle generator from the system RNG. If specified, repeated runs with the same configuration,
 seed, and thread setup will be reproducible.
 
+A single integer is broadcast to all sublattices (each sublattice receives `seed + sublattice_index`).
+Alternatively, a list of seeds (one per sublattice) can be provided, where each entry is either an
+integer or `null` to leave that sublattice unseeded.
+
+:::{warning}
+Seeded runs require `thread_config` to be exactly **1**. Setting a seed with multiple threads will
+raise a configuration error because the shuffler is not thread-safe and reproducibility cannot be
+guaranteed.
+:::
+
 - **Required:** No
 - **Default:** randomly generated
-- **Accepted:** unsigned 64-bit integer (`int`)
+- **Accepted:** unsigned 64-bit integer (`int`) or list of `int | null`
 
   ::::{tab} JSON
   :::{code-block} json
   {
     "seed": 42
+  }
+  :::
+  :::{code-block} json
+  {
+    "seed": [42, null, 123]
   }
   :::
   ::::
@@ -119,6 +134,11 @@ seed, and thread setup will be reproducible.
   :::{code-block} python
   {
       "seed": 42
+  }
+  :::
+  :::{code-block} python
+  {
+      "seed": [42, None, 123]
   }
   :::
   ::::

--- a/include/sqsgen/core/config.h
+++ b/include/sqsgen/core/config.h
@@ -32,7 +32,7 @@ namespace sqsgen::core {
   template <class T> struct configuration {
     SublatticeMode sublattice_mode;
     IterationMode iteration_mode;
-    std::optional<std::uint64_t> seed;
+    seed_t seed;
     structure_config<T> structure;
     std::vector<sublattice> composition;
     stl_matrix_t<T> shell_radii;

--- a/include/sqsgen/core/config.h
+++ b/include/sqsgen/core/config.h
@@ -5,6 +5,9 @@
 #ifndef SQSGEN_CONFIGURATION_H
 #define SQSGEN_CONFIGURATION_H
 
+#include <cstdint>
+#include <optional>
+
 #include "sqsgen/core/structure.h"
 
 namespace sqsgen::core {
@@ -29,6 +32,7 @@ namespace sqsgen::core {
   template <class T> struct configuration {
     SublatticeMode sublattice_mode;
     IterationMode iteration_mode;
+    std::optional<std::uint64_t> seed;
     structure_config<T> structure;
     std::vector<sublattice> composition;
     stl_matrix_t<T> shell_radii;

--- a/include/sqsgen/core/optimization_config.h
+++ b/include/sqsgen/core/optimization_config.h
@@ -51,9 +51,15 @@ namespace sqsgen::core {
     sqsgen::core::shuffler shuffler;
 
     static std::optional<std::uint64_t> seed_for_sublattice(
-        std::optional<std::uint64_t> seed, std::size_t index) {
+        seed_t const& seed, std::size_t index) {
       if (!seed.has_value()) return std::nullopt;
-      return seed.value() + static_cast<std::uint64_t>(index);
+      auto const& seeds = seed.value();
+      if (seeds.size() == 1)
+        return seeds[0].has_value()
+                   ? std::optional{seeds[0].value() + static_cast<std::uint64_t>(index)}
+                   : std::nullopt;
+      if (index < seeds.size()) return seeds[index];
+      return std::nullopt;
     }
 
     static std::vector<optimization_config> from_config(configuration<T> config) {

--- a/include/sqsgen/core/optimization_config.h
+++ b/include/sqsgen/core/optimization_config.h
@@ -50,6 +50,12 @@ namespace sqsgen::core {
   template <class T, SublatticeMode Mode> struct optimization_config : optimization_config_data<T> {
     sqsgen::core::shuffler shuffler;
 
+    static std::optional<std::uint64_t> seed_for_sublattice(
+        std::optional<std::uint64_t> seed, std::size_t index) {
+      if (!seed.has_value()) return std::nullopt;
+      return seed.value() + static_cast<std::uint64_t>(index);
+    }
+
     static std::vector<optimization_config> from_config(configuration<T> config) {
       auto [structures, sorted, bounds, sort_order] = decompose_sort_and_bounds(config);
       if (!core::detail::same_length(structures, sorted, bounds, sort_order, config.shell_radii,
@@ -86,7 +92,8 @@ namespace sqsgen::core {
                                 std::move(config.target_objective[i]),
                                 std::move(config.shell_radii[i]),
                                 std::move(config.shell_weights[i]),
-                                core::shuffler({bounds[i]})});
+                                core::shuffler({bounds[i]},
+                                               seed_for_sublattice(config.seed, i))});
       }
       return configs;
     }

--- a/include/sqsgen/io/config/combined.h
+++ b/include/sqsgen/io/config/combined.h
@@ -45,13 +45,15 @@ namespace sqsgen::io::config {
   }
 
   template <string_literal key, class Document>
-  parse_result<std::optional<std::uint64_t>> parse_seed(Document const& document) {
-    if (auto seed = get_optional<key, std::uint64_t>(document); seed.has_value())
-      return seed.value().and_then(
-          [](auto&& value) -> parse_result<std::optional<std::uint64_t>> {
-            return {std::optional<std::uint64_t>{value}};
-          });
-    return {std::optional<std::uint64_t>{std::nullopt}};
+  parse_result<seed_t> parse_seed(Document const& document) {
+    using result_t = parse_result<seed_t>;
+    using seed_list_t = std::vector<std::optional<std::uint64_t>>;
+    if (auto seed = get_either_optional<key, std::uint64_t, seed_list_t>(document);
+        seed.has_value())
+      return seed.value().template collapse<seed_t>(
+          [](std::uint64_t&& value) -> result_t { return {seed_t{seed_list_t{value}}}; },
+          [](seed_list_t&& values) -> result_t { return {seed_t{std::move(values)}}; });
+    return {seed_t{std::nullopt}};
   }
 
   template <string_literal key, class Document, class T>
@@ -175,7 +177,7 @@ namespace sqsgen::io::config {
         .combine(parse_seed<"seed">(doc))
         .combine(parse_sublattice_mode<"sublattice_mode">(doc))
         .and_then([](auto&& modes)
-                      -> parse_result<std::tuple<IterationMode, std::optional<std::uint64_t>,
+                      -> parse_result<std::tuple<IterationMode, seed_t,
                                                  SublatticeMode>> {
           auto [iteration_mode, seed, sublattice_mode] = modes;
           if (iteration_mode == ITERATION_MODE_SYSTEMATIC
@@ -225,6 +227,22 @@ namespace sqsgen::io::config {
                                   auto [prefactors, pair_weights, target_objective, chunk_size,
                                         thread_config, to_keep, max_results_per_objective]
                                       = arrays;
+                                  if (seed.has_value()
+                                      && std::any_of(thread_config.begin(), thread_config.end(),
+                                                     [](auto t) { return t > 1; }))
+                                    return {parse_error::from_msg<"seed", CODE_BAD_VALUE>(
+                                        "A random seed is set but the thread configuration "
+                                        "specifies more than 1 thread; seeded runs require "
+                                        "exactly 1 thread for reproducibility")};
+                                  if (seed.has_value()
+                                      && seed.value().size() != 1
+                                      && seed.value().size() != composition.size())
+                                    return {parse_error::from_msg<"seed", CODE_BAD_VALUE>(
+                                        format_string(
+                                            "The seed list has %u entries but the configuration "
+                                            "has %u sublattice(s); provide either a single seed "
+                                            "or one per sublattice",
+                                            seed.value().size(), composition.size()))};
                                   return configuration<T>{
                                       sublattice_mode,
                                       iteration_mode,

--- a/include/sqsgen/io/config/combined.h
+++ b/include/sqsgen/io/config/combined.h
@@ -16,6 +16,7 @@
 namespace sqsgen::io::config {
   static constexpr auto KNOWN_KEYS = std::array{"iteration_mode",
                                                 "sublattice_mode",
+                                                "seed",
                                                 "structure",
                                                 "composition",
                                                 "shell_radii",
@@ -41,6 +42,16 @@ namespace sqsgen::io::config {
   parse_result<IterationMode> parse_iteration_mode(Document const& document) {
     return get_optional<key, IterationMode>(document).value_or(
         parse_result<IterationMode>{ITERATION_MODE_RANDOM});
+  }
+
+  template <string_literal key, class Document>
+  parse_result<std::optional<std::uint64_t>> parse_seed(Document const& document) {
+    if (auto seed = get_optional<key, std::uint64_t>(document); seed.has_value())
+      return seed.value().and_then(
+          [](auto&& value) -> parse_result<std::optional<std::uint64_t>> {
+            return {std::optional<std::uint64_t>{value}};
+          });
+    return {std::optional<std::uint64_t>{std::nullopt}};
   }
 
   template <string_literal key, class Document, class T>
@@ -161,9 +172,12 @@ namespace sqsgen::io::config {
     auto validation_result = accessor<Document>::validate_keys(doc, KNOWN_KEYS);
     if (validation_result.has_value()) return {*validation_result};
     return parse_iteration_mode<"iteration_mode">(doc)
+        .combine(parse_seed<"seed">(doc))
         .combine(parse_sublattice_mode<"sublattice_mode">(doc))
-        .and_then([](auto&& modes) -> parse_result<std::tuple<IterationMode, SublatticeMode>> {
-          auto [iteration_mode, sublattice_mode] = modes;
+        .and_then([](auto&& modes)
+                      -> parse_result<std::tuple<IterationMode, std::optional<std::uint64_t>,
+                                                 SublatticeMode>> {
+          auto [iteration_mode, seed, sublattice_mode] = modes;
           if (iteration_mode == ITERATION_MODE_SYSTEMATIC
               && sublattice_mode == SUBLATTICE_MODE_SPLIT)
             return {parse_error::from_msg<"iteration_mode", CODE_BAD_VALUE>(
@@ -173,7 +187,7 @@ namespace sqsgen::io::config {
         })
         .combine(parse_structure_config<"structure", T>(doc))
         .and_then([&](auto&& sc_and_modes) {
-          auto [iteration_mode, sublattice_mode, sc] = sc_and_modes;
+          auto [iteration_mode, seed, sublattice_mode, sc] = sc_and_modes;
           auto structure = sc.structure();
           return config::parse_composition<"composition", "sites">(doc, structure.species,
                                                                    sublattice_mode)
@@ -214,6 +228,7 @@ namespace sqsgen::io::config {
                                   return configuration<T>{
                                       sublattice_mode,
                                       iteration_mode,
+                                      seed,
                                       std::forward<structure_config<T>>(sc),
                                       std::forward<std::vector<sublattice>>(composition),
                                       std::forward<stl_matrix_t<T>>(radii),

--- a/include/sqsgen/io/json.h
+++ b/include/sqsgen/io/json.h
@@ -158,6 +158,7 @@ template <class T> struct adl_serializer<core::configuration<T>> {
   static void to_json(json& j, core::configuration<T> const& data) {
     j = json{{"sublattice_mode", data.sublattice_mode},
              {"iteration_mode", data.iteration_mode},
+             {"seed", data.seed},
              {"structure", data.structure},
              {"composition", data.composition},
              {"shell_radii", data.shell_radii},
@@ -175,6 +176,10 @@ template <class T> struct adl_serializer<core::configuration<T>> {
   static void from_json(const json& j, core::configuration<T>& c) {
     j.at("sublattice_mode").get_to<SublatticeMode>(c.sublattice_mode);
     j.at("iteration_mode").get_to<IterationMode>(c.iteration_mode);
+    if (j.contains("seed"))
+      j.at("seed").get_to<std::optional<std::uint64_t>>(c.seed);
+    else
+      c.seed = std::nullopt;
     j.at("structure").get_to<core::structure_config<T>>(c.structure);
     j.at("composition").get_to<std::vector<sublattice>>(c.composition);
     j.at("shell_radii").get_to<stl_matrix_t<T>>(c.shell_radii);

--- a/include/sqsgen/io/json.h
+++ b/include/sqsgen/io/json.h
@@ -50,6 +50,25 @@ template <class T, long Dims> struct binary_adapter {
 };
 
 using namespace sqsgen;
+
+template <class T> struct adl_serializer<std::optional<T>> {
+  static void to_json(json& j, const std::optional<T>& opt) {
+    if (opt.has_value()) {
+      j = *opt;
+    } else {
+      j = nullptr;
+    }
+  }
+
+  static void from_json(const json& j, std::optional<T>& opt) {
+    if (j.is_null()) {
+      opt = std::nullopt;
+    } else {
+      opt = j.get<T>();
+    }
+  }
+};
+
 template <class T> struct adl_serializer<matrix_t<T>> {
   static void to_json(json& j, const matrix_t<T>& m) { j = core::helpers::eigen_to_stl(m); }
 
@@ -176,9 +195,13 @@ template <class T> struct adl_serializer<core::configuration<T>> {
   static void from_json(const json& j, core::configuration<T>& c) {
     j.at("sublattice_mode").get_to<SublatticeMode>(c.sublattice_mode);
     j.at("iteration_mode").get_to<IterationMode>(c.iteration_mode);
-    if (j.contains("seed"))
-      j.at("seed").get_to<std::optional<std::uint64_t>>(c.seed);
-    else
+    if (j.contains("seed") && !j.at("seed").is_null()) {
+      auto const& s = j.at("seed");
+      if (s.is_number_unsigned())
+        c.seed = std::vector<std::optional<std::uint64_t>>{s.get<std::uint64_t>()};
+      else
+        c.seed = s.get<std::vector<std::optional<std::uint64_t>>>();
+    } else
       c.seed = std::nullopt;
     j.at("structure").get_to<core::structure_config<T>>(c.structure);
     j.at("composition").get_to<std::vector<sublattice>>(c.composition);
@@ -267,24 +290,6 @@ template <class T, SublatticeMode Mode> struct adl_serializer<core::sqs_result_p
                                        sqs_statistics_data<T>{}};
     p.config = config;
     j.at("statistics").get_to<sqs_statistics_data<T>>(p.statistics);
-  }
-};
-
-template <class T> struct adl_serializer<std::optional<T>> {
-  static void to_json(json& j, const std::optional<T>& opt) {
-    if (opt.has_value()) {
-      j = *opt;
-    } else {
-      j = nullptr;
-    }
-  }
-
-  static void from_json(const json& j, std::optional<T>& opt) {
-    if (j.is_null()) {
-      opt = std::nullopt;
-    } else {
-      opt = j.get<T>();
-    }
   }
 };
 

--- a/include/sqsgen/types.h
+++ b/include/sqsgen/types.h
@@ -85,6 +85,8 @@ namespace sqsgen {
 
   using thread_config_t = std::vector<usize_t>;
 
+  using seed_t = std::optional<std::vector<std::optional<std::uint64_t>>>;
+
   struct sublattice {
     vset<usize_t> sites;
     composition_t composition;

--- a/js/wasm/sqsgen.cpp
+++ b/js/wasm/sqsgen.cpp
@@ -138,6 +138,16 @@ val optimize(val const& config, sqsgen::Prec prec, val const& cb) {
       run_config = from_json<configuration<float>>(config_json);
     else
       run_config = from_json<configuration<double>>(config_json);
+    std::visit(
+        [](auto&& c) {
+          if (c.seed.has_value()
+              && std::any_of(c.thread_config.begin(), c.thread_config.end(),
+                             [](auto t) { return t > 1; }))
+            throw std::invalid_argument(
+                "A random seed is set but the thread configuration specifies more than 1 "
+                "thread; seeded runs require exactly 1 thread for reproducibility");
+        },
+        run_config);
     thread_local ProxyingQueue proxying_queue_main;
 
     std::optional<sqs_callback_t> callback;

--- a/python/extension/sqsgen.cpp
+++ b/python/extension/sqsgen.cpp
@@ -206,6 +206,7 @@ template <string_literal Name, class T> void bind_configuration(py::module &m) {
   py::class_<configuration<T>>(m, format_prec<Name, T>().c_str())
       .def_readwrite("sublattice_mode", &configuration<T>::sublattice_mode)
       .def_readwrite("iteration_mode", &configuration<T>::iteration_mode)
+      .def_readwrite("seed", &configuration<T>::seed)
       .def(
           "structure", [](configuration<T> &conf) { return conf.structure.structure(); },
           py::return_value_policy::move)

--- a/python/sqsgenerator/core/_core.pyi
+++ b/python/sqsgenerator/core/_core.pyi
@@ -222,6 +222,7 @@ class SqsConfigurationDouble:
     prefactors: Incomplete
     shell_radii: list[list[float]]
     shell_weights: list[dict[int, float]]
+    seed: int | None
     sublattice_mode: SublatticeMode
     target_objective: Incomplete
     thread_config: list[int]
@@ -241,6 +242,7 @@ class SqsConfigurationFloat:
     prefactors: Incomplete
     shell_radii: list[list[float]]
     shell_weights: list[dict[int, float]]
+    seed: int | None
     sublattice_mode: SublatticeMode
     target_objective: Incomplete
     thread_config: list[int]

--- a/python/sqsgenerator/core/_core.pyi
+++ b/python/sqsgenerator/core/_core.pyi
@@ -222,7 +222,7 @@ class SqsConfigurationDouble:
     prefactors: Incomplete
     shell_radii: list[list[float]]
     shell_weights: list[dict[int, float]]
-    seed: int | None
+    seed: list[int | None] | None
     sublattice_mode: SublatticeMode
     target_objective: Incomplete
     thread_config: list[int]
@@ -242,7 +242,7 @@ class SqsConfigurationFloat:
     prefactors: Incomplete
     shell_radii: list[list[float]]
     shell_weights: list[dict[int, float]]
-    seed: int | None
+    seed: list[int | None] | None
     sublattice_mode: SublatticeMode
     target_objective: Incomplete
     thread_config: list[int]

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -298,12 +298,12 @@ def test_random_seed_reproducible(prec):
     config_a = parse_config(settings)
     config_b = parse_config(settings)
 
-    assert config_a.seed == config_b.seed == 42
+    assert config_a.seed == config_b.seed == [42]
 
     results_a = optimize(config_a)
     results_b = optimize(config_b)
 
-    assert results_a.config.seed == results_b.config.seed == 42
+    assert results_a.config.seed == results_b.config.seed == [42]
     solutions_a = collections.Counter(
         (round(float(sol.objective), 12), tuple(sol.structure().species))
         for _, result_set in results_a
@@ -315,3 +315,17 @@ def test_random_seed_reproducible(prec):
         for sol in result_set
     )
     assert solutions_a == solutions_b
+
+
+@pytest.mark.parametrize("prec", [single, double])
+def test_random_seed_with_multiple_threads_fails(prec):
+    from sqsgenerator.core._core import ParseError
+
+    settings = default_settings(prec)
+    settings["iteration_mode"] = random
+    settings["iterations"] = 500
+    settings["seed"] = 42
+    settings["thread_config"] = 4
+
+    config = parse_config(settings)
+    assert isinstance(config, ParseError)

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -286,3 +286,32 @@ def test_bonds_correct_one_sublattice_non_exhaustive(prec):
         print(config.msg)
     results = optimize(config)
     assert_bonds_correct_interact(results, config)
+
+
+@pytest.mark.parametrize("prec", [single, double])
+def test_random_seed_reproducible(prec):
+    settings = default_settings(prec)
+    settings["iteration_mode"] = random
+    settings["iterations"] = 500
+    settings["seed"] = 42
+
+    config_a = parse_config(settings)
+    config_b = parse_config(settings)
+
+    assert config_a.seed == config_b.seed == 42
+
+    results_a = optimize(config_a)
+    results_b = optimize(config_b)
+
+    assert results_a.config.seed == results_b.config.seed == 42
+    solutions_a = collections.Counter(
+        (round(float(sol.objective), 12), tuple(sol.structure().species))
+        for _, result_set in results_a
+        for sol in result_set
+    )
+    solutions_b = collections.Counter(
+        (round(float(sol.objective), 12), tuple(sol.structure().species))
+        for _, result_set in results_b
+        for sol in result_set
+    )
+    assert solutions_a == solutions_b


### PR DESCRIPTION
Thanks for maintaining this amazing package, I have been using it recently and it is very helpful! 😊

For reproducibility during debugging I have forked the repo and exposed the random seed to the Python API. Before I used a workaround by hashing the generated structures afterward to check whether repeated runs were effectively deterministic. Exposing the seed directly through the Python binding is more elegant and I am wondering if this could be a useful feature for the project.

Here a summary of the changes:

## Changes
- add `seed: Optional[uint64]` to the core configuration
- parse `seed` from dict/JSON config input
- include `seed` in JSON serialization
- expose `seed` in the Python bindings
- pass the configured seed into the internal shuffler
- document seed in the parameter docs
- add a Python test for reproducibility

## Notes
- this affects `iteration_mode="random"`
- reproducibility should hold for the same configuration, seed, and thread setup
- the new test uses thread_config=1 to keep the reproducibility guarantee explicit

## Verification
- a config with and without `seed` parses successfully
- repeated runs with the same seed produce the same objective value and the same species assignment